### PR TITLE
Migrate to a static-web-server docker image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: "Deploy"
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: Deploy to Sliplane.io
+    steps:
+      - uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: type=edge
+        id: meta
+      - uses: actions/checkout@v6
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:cache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:cache,mode=max
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          target: runtime
+      - run: |
+          curl "https://api.sliplane.io/deploy/service_v9feqwrnq2ko/${{ secrets.SLIPLANE_SECRET }}"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,8 +1,6 @@
-name: "Build and verify"
+name: "Test & validate"
 
 on:
-  push:
-    branches: [master]
   pull_request:
     branches: [master]
   workflow_dispatch:
@@ -10,7 +8,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    name: Build and verify
+    name: Validate & lint
     container: ruby:3.4
     env:
       BUNDLE_FROZEN: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ruby:3.4 AS builder
+
+RUN mkdir -p /workspace
+WORKDIR /workspace
+
+COPY Gemfile Gemfile.lock ./
+ENV BUNLDE_WITHOUT=development:test
+RUN bundle install
+
+RUN --mount=type=bind,target=/workspace,rw \
+    bundle exec jekyll build --destination /var/_site
+
+FROM joseluisq/static-web-server:2 AS runtime
+
+COPY --from=builder /var/_site /var/public
+ENTRYPOINT ["/static-web-server", "--root=/var/public", "--health"]


### PR DESCRIPTION
Adds a docker file which serves the pre-built jekyll site using a rust-based server, published to ghcr.io and deployed to sliplane.io.